### PR TITLE
Fixed issue with calling DateTimeZone::listIdentifiers without a coun…

### DIFF
--- a/src/Date.php
+++ b/src/Date.php
@@ -279,7 +279,11 @@ class Date
             "UTC"
         ));
 
-        $listing = DateTimeZone::listIdentifiers(DateTimeZone::PER_COUNTRY, $country);
+        if ($country) {
+            $listing = DateTimeZone::listIdentifiers(DateTimeZone::PER_COUNTRY, $country);
+        } else {
+            $listing = DateTimeZone::listIdentifiers();
+        }
         $num_listings = count($listing);
 
         // Associate each timezone identifier with its meta data


### PR DESCRIPTION
…try specified, which lead to an error
- DateTimeZone::listIdentifiers(): A two-letter ISO 3166-1 compatible country code is expected

Fixes #3
